### PR TITLE
Don't connect to pulseaudio with PA_CONTEXT_NOFAIL

### DIFF
--- a/pulse.cc
+++ b/pulse.cc
@@ -114,7 +114,7 @@ PulseClient::PulseClient(string client_name) :
   pa_proplist_free(proplist);
 
   pa_context_set_state_callback(context_, connect_state_cb, &state);
-  pa_context_connect(context_, nullptr, PA_CONTEXT_NOFAIL, nullptr);
+  pa_context_connect(context_, nullptr, PA_CONTEXT_NOFLAGS, nullptr);
   while (state != PA_CONTEXT_READY && state != PA_CONTEXT_FAILED) {
     pa_mainloop_iterate(mainloop_, 1, nullptr);
   }


### PR DESCRIPTION
NOFAIL means we don't fail if the daemon is not available when `pa_context_connect()` is called and instead enter `PA_CONTEXT_CONNECTING` state and wait for the daemon to appear.

So currently if pulseaudio isn't running or available, ponymix will just block and wait. Since a lot of people use ponymix bound to their volume keys, this could potentially mean spawning 100s of processes before actually catching on that things aren't working.

`PA_CONTEXT_NOFLAGS` was introduced in 0.9.19. Its really just 0.

Signed-off-by: Simon Gomizelj simongmzlj@gmail.com
