### PR TITLE
Clamp volumes between a more intelligent range

### DIFF
--- a/ponymix.cc
+++ b/ponymix.cc
@@ -325,7 +325,7 @@ static int adj_volume(PulseClient& ponymix,
     errx(1, "error: failed to convert string to integer: %s", argv[0]);
   }
 
-  ponymix.SetVolumeRange(0, 100);
+  ponymix.SetVolumeRange(0, device->Volume());
   return !(ponymix.*adjust)(*device, delta);
 }
 


### PR DESCRIPTION
This handles volume increment/decrement better when volume is >100%.

If volume is above 100%, incrementing or decrementing the volume will automatically drop it back down to 100%. It be better if decrementing worked as expected and we just didn't increment the volume further.
