### PR TITLE
Fix segfault when an invalid command is issued

### DIFF
--- a/ponymix.cc
+++ b/ponymix.cc
@@ -457,6 +457,10 @@ static const std::pair<const string, const Command>& string_to_command(
 
   const auto match = actionmap.lower_bound(str);
 
+  if (match == actionmap.end()) {
+    errx(1, "error: Invalid action specified: %s", str);
+  }
+
   // Check for exact match
   if (match->first == str) {
     return *match;


### PR DESCRIPTION
First check if we actually find an entry inside the action map before processing it further.
