### PR TITLE
Support checking for headphones

### DIFF
--- a/ponymix.cc
+++ b/ponymix.cc
@@ -196,6 +196,11 @@ static int ShowDefaults(PulseClient& ponymix, int, char*[]) {
   return 0;
 }
 
+static int HeadphonesCheck(PulseClient& ponymix, int, char*[]) {
+  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  return !device->PortAvailable();
+}
+
 static int List(PulseClient& ponymix, int, char*[]) {
   if (opt_listrestrict) {
     for (const auto& d : ponymix.GetDevices(opt_devtype)) Print(d);
@@ -430,7 +435,8 @@ static const std::pair<const string, const Command>& string_to_command(
     { "get-profile",         { GetProfile,          { 0, 0 } } },
     { "set-profile",         { SetProfile,          { 1, 1 } } },
     { "move",                { Move,                { 1, 1 } } },
-    { "kill",                { Kill,                { 0, 0 } } }
+    { "kill",                { Kill,                { 0, 0 } } },
+    { "headphones",          { HeadphonesCheck,     { 0, 0 } } }
   };
 
   const auto match = actionmap.lower_bound(str);
@@ -509,6 +515,7 @@ static void usage() {
         "  toggle                 toggle mute\n"
         "  is-muted               check if muted\n", stdout);
   fputs("\nApplication Commands:\n"
+        "  headphones             check if headphones are plugged in\n"
         "  move DEVICE            move target device to DEVICE\n"
         "  kill DEVICE            kill target DEVICE\n", stdout);
 

--- a/pulse.cc
+++ b/pulse.cc
@@ -590,6 +590,7 @@ Device::Device(const pa_sink_info* info) :
   update_volume(info->volume);
   memcpy(&channels_, &info->channel_map, sizeof(pa_channel_map));
   balance_ = pa_cvolume_get_balance(&volume_, &channels_) * 100.0;
+  port_available_ = (info->active_port->available == PA_PORT_AVAILABLE_YES);
 
   ops_.SetVolume = pa_context_set_sink_volume_by_index;
   ops_.Mute = pa_context_set_sink_mute_by_index;

--- a/pulse.h
+++ b/pulse.h
@@ -58,6 +58,7 @@ class Device {
   const string& Desc() const { return desc_; }
   int Volume() const { return volume_percent_; }
   int Balance() const { return balance_; }
+  bool PortAvailable() const { return port_available_; }
   bool Muted() const { return mute_; }
   enum DeviceType Type() const { return type_; }
 
@@ -74,6 +75,7 @@ class Device {
   int volume_percent_;
   pa_channel_map channels_;
   int mute_;
+  bool port_available_;
   int balance_;
   uint32_t card_idx_;
   Operations ops_;


### PR DESCRIPTION
Codifying #23. This checks the active port's jack, to see if it's 'available'. Not all devices support that, which will return PA_PORT_AVAILABLE_UNKNOWN. Those are presented as not having headphones plugged in.

Not sure if this really matches your own style, it's been a long time since I programmed C++.
