### PR TITLE
Resolve devices by name only: #31

### DIFF
--- a/ponymix.cc
+++ b/ponymix.cc
@@ -101,22 +101,29 @@ static enum DeviceType string_to_devtype_or_die(const char* str) {
   }
 }
 
-static Device* string_to_device_or_die(PulseClient& ponymix,
-                                       string arg) {
+static Device* string_to_device_or_die(PulseClient& ponymix, string arg) {
   for (const auto& s : ponymix.GetSinks()) {
-    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SINK);}
+    if (s.Name() == arg) {
+      return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SINK);
+    }
   }
 
   for (const auto& s : ponymix.GetSources()) {
-    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SOURCE);}
+    if (s.Name() == arg) {
+      return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SOURCE);
+    }
   }
 
   for (const auto& s : ponymix.GetSinkInputs()) {
-    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SINK_INPUT);}
+    if (s.Name() == arg) {
+      return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SINK_INPUT);
+    }
   }
 
   for (const auto& s : ponymix.GetSourceOutputs()) {
-    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SOURCE_OUTPUT);}
+    if (s.Name() == arg) {
+      return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SOURCE_OUTPUT);
+    }
   }
 
   errx(1, "no match found for device: %s", arg.c_str());

--- a/ponymix.cc
+++ b/ponymix.cc
@@ -241,7 +241,7 @@ static int ListCards(PulseClient& ponymix, int, char*[]) {
 static Card* resolve_active_card_or_die(PulseClient& ponymix) {
   Card* card;
   if (opt_card == nullptr) {
-    auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+    auto device = string_to_device_or_die(ponymix, opt_device);
     card = ponymix.GetCard(*device);
     if (card == nullptr) errx(1, "error: no card found or selected.");
   } else {
@@ -263,13 +263,13 @@ static int ListProfiles(PulseClient& ponymix, int, char*[]) {
   return 0;}
 
 static int GetVolume(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   printf("%d\n", device->Volume());
   return 0;
 }
 
 static int SetVolume(PulseClient& ponymix, int, char* argv[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
 
   long volume;
   try {
@@ -282,13 +282,13 @@ static int SetVolume(PulseClient& ponymix, int, char* argv[]) {
 }
 
 static int GetBalance(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   printf("%d\n", device->Balance());
   return 0;
 }
 
 static int SetBalance(PulseClient& ponymix, int, char* argv[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
 
   long balance;
   try {
@@ -301,7 +301,7 @@ static int SetBalance(PulseClient& ponymix, int, char* argv[]) {
 }
 
 static int AdjBalance(PulseClient& ponymix, int, char* argv[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
 
   long balance;
   try {
@@ -316,7 +316,7 @@ static int AdjBalance(PulseClient& ponymix, int, char* argv[]) {
 static int adj_volume(PulseClient& ponymix,
                       bool (PulseClient::*adjust)(Device&, long int),
                       char* argv[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
 
   long delta;
   try {
@@ -340,27 +340,27 @@ static int DecreaseVolume(PulseClient& ponymix, int, char* argv[]) {
 }
 
 static int Mute(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   return !ponymix.SetMute(*device, true);
 }
 
 static int Unmute(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   return !ponymix.SetMute(*device, false);
 }
 
 static int ToggleMute(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   return !ponymix.SetMute(*device, !ponymix.IsMuted(*device));
 }
 
 static int IsMuted(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   return !ponymix.IsMuted(*device);
 }
 
 static int SetDefault(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   return !ponymix.SetDefault(*device);
 }
 
@@ -393,8 +393,8 @@ static int Move(PulseClient& ponymix, int, char* argv[]) {
   }
 
   // Does this even work?
-  auto source = string_to_device_or_die(ponymix, opt_device, opt_devtype);
-  auto target = string_to_device_or_die(ponymix, argv[0], target_devtype);
+  auto source = string_to_device_or_die(ponymix, opt_device);
+  auto target = string_to_device_or_die(ponymix, argv[0]);
 
   return !ponymix.Move(*source, *target);
 }
@@ -411,13 +411,13 @@ static int Kill(PulseClient& ponymix, int, char*[]) {
     break;
   }
 
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
 
   return !ponymix.Kill(*device);
 }
 
 static int IsAvailable(PulseClient& ponymix, int, char*[]) {
-  auto device = string_to_device_or_die(ponymix, opt_device, opt_devtype);
+  auto device = string_to_device_or_die(ponymix, opt_device);
   return ponymix.Availability(*device) == Device::AVAILABLE_YES;
 }
 
@@ -674,7 +674,10 @@ int main(int argc, char* argv[]) {
   // that on demand if a function needs it.
   ServerInfo defaults = ponymix.GetDefaults();
   opt_action = "defaults";
+
+  // Silently ignored unless a specific device is targeted
   opt_devtype = DEVTYPE_SINK;
+
   opt_maxvolume = 100;
 
   if (!parse_options(argc, argv)) return 1;

--- a/ponymix.cc
+++ b/ponymix.cc
@@ -129,14 +129,6 @@ static Device* string_to_device_or_die(PulseClient& ponymix, string arg) {
   errx(1, "no match found for device: %s", arg.c_str());
 }
 
-static Device* string_to_device_or_die(PulseClient& ponymix,
-                                       string arg,
-                                       enum DeviceType type) {
-  Device* device = ponymix.GetDevice(arg, type);
-  if (device == nullptr) errx(1, "no match found for device: %s", arg.c_str());
-  return device;
-}
-
 static void Print(const Device& device) {
   if (opt_short) {
     printf("%s\t%d\t%s\t%s\n",

--- a/ponymix.cc
+++ b/ponymix.cc
@@ -102,6 +102,27 @@ static enum DeviceType string_to_devtype_or_die(const char* str) {
 }
 
 static Device* string_to_device_or_die(PulseClient& ponymix,
+                                       string arg) {
+  for (const auto& s : ponymix.GetSinks()) {
+    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SINK);}
+  }
+
+  for (const auto& s : ponymix.GetSources()) {
+    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SOURCE);}
+  }
+
+  for (const auto& s : ponymix.GetSinkInputs()) {
+    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SINK_INPUT);}
+  }
+
+  for (const auto& s : ponymix.GetSourceOutputs()) {
+    if (s.Name() == arg) {return ponymix.GetDevice(arg, DeviceType::DEVTYPE_SOURCE_OUTPUT);}
+  }
+
+  errx(1, "no match found for device: %s", arg.c_str());
+}
+
+static Device* string_to_device_or_die(PulseClient& ponymix,
                                        string arg,
                                        enum DeviceType type) {
   Device* device = ponymix.GetDevice(arg, type);


### PR DESCRIPTION
This patch addresses issue #31 :

`ponymix` now resolves devices using only the name of the devices specified. The `--source` and `--sink` keywords are silently ignored. On the other hand, if no device is explicitly requested, the keywords will result in the name of the respective default device being queried. Actions are then taken based on the resulting name only.

Note: targetting the monitor of a device by supplying it with the complement keyword is no longer possible. For example:

```
% ponymix --source -d alsa_output.pci-0000_00_1b.0.analog-stereo
```

This used to target the _source_ of the output device, which in this case has the full name `alsa_output.pci-0000_00_1b.0.analog-stereo.monitor`. Maybe we could introduce a `--monitor` flag?
