### PR TITLE
C++11 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifneq "$(VDEVEL)" ""
 V=$(VDEVEL)
 endif
 
-base_CXXFLAGS = -std=c++14 -Wall -Wextra -pedantic -O2 -g -DPONYMIX_VERSION=\"$(V)\"
+base_CXXFLAGS = -std=c++11 -Wall -Wextra -pedantic -O2 -g -DPONYMIX_VERSION=\"$(V)\"
 base_LIBS = -lm
 
 libpulse_CXXFLAGS = $(shell pkg-config --cflags libpulse)

--- a/ponymix.cc
+++ b/ponymix.cc
@@ -1,4 +1,5 @@
 #include "pulse.h"
+#include "unique_polyfill.h"
 
 #include <err.h>
 #include <getopt.h>

--- a/unique_polyfill.h
+++ b/unique_polyfill.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// MSVS defines this already.
+// http://stackoverflow.com/questions/14131454/visual-studio-2012-cplusplus-and-c-11
+#if defined(_MSC_VER) && _MSC_VER < 1800 || !defined(_MSC_VER) && __cplusplus <= 201103L
+#include <memory>
+#include <utility>
+namespace std {
+  // C++14 backfill from http://herbsutter.com/gotw/_102/
+  template<typename T, typename ...Args>
+    inline std::unique_ptr<T> make_unique(Args&& ...args) {
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+  }
+}
+#endif


### PR DESCRIPTION
Added Herb Sutters C++11 backfill for `std::make_unique`. Compiles on Ubuntu 14.04 with g++ 4.8.4.  